### PR TITLE
About the key words in judging that the comment is spams.

### DIFF
--- a/utilities/check-spam.js
+++ b/utilities/check-spam.js
@@ -19,7 +19,7 @@ exports.checkSpam = (comment, ip) => {
       //关键词用半角逗号分隔
       var words = process.env.SPAM_WORDS;
       words.split(',').forEach(item => {
-        if (comment.get('comment').indexOf(item) >= 0){P
+        if (comment.get('comment').indexOf(item) >= 0){
           console.log('检测到含有关键词!')
           comment.set('isSpam', true)
           comment.setACL(new AV.ACL({ '*': { read: false } }))

--- a/utilities/check-spam.js
+++ b/utilities/check-spam.js
@@ -13,6 +13,21 @@ exports.checkSpam = (comment, ip) => {
     comment.set('isSpam', true)
     comment.save()
     return
+  } else {
+    if (process.env.SPAM_WORDS) {
+      console.log('检测到添加屏蔽关键词，进行关键词检验')
+      //关键词用半角逗号分隔
+      var words = process.env.SPAM_WORDS;
+      words.split(',').forEach(item => {
+        if (comment.get('comment').indexOf(item) >= 0){P
+          console.log('检测到含有关键词!')
+          comment.set('isSpam', true)
+          comment.setACL(new AV.ACL({ '*': { read: false } }))
+          // 阻止被屏蔽的评论提交
+          comment.destroy();
+        }
+      })
+    }
   }
   akismetClient.verifyKey(function (err, valid) {
     if (err) console.log('Akismet key 异常:', err.message)


### PR DESCRIPTION
When using Valine comment system, there are some ads can't be defended which bother me, so I add a key word defender to make it can be in control.

We can only add a new envioronment variable named SPAM_WORDS, and split it with ',', so that it will work to destroy the useless comments.